### PR TITLE
Allow for Async Page Components

### DIFF
--- a/client/src/init/router.js
+++ b/client/src/init/router.js
@@ -37,13 +37,14 @@ const parse = (params = {}) => {
 
 const routeHandler =
   (pageBody) =>
-  ({ params, data }) => {
+  async ({ params, data }) => {
     const namedRoutes = routes.filter((route) => `name` in route);
     const cleanData = { ...data };
     cleanData.id = !data || !('id' in data) ? -1 : data.id;
     const root = document.getElementById('root');
     root.innerHTML = '';
-    root.appendChild(page(pageBody(parse(data), parse(params)), namedRoutes));
+    const body = await pageBody(parse(data), parse(params));
+    root.appendChild(page(body, namedRoutes));
   };
 
 routes


### PR DESCRIPTION
Currently routes map directly to components, this means components themselves need to fetch the necessary data.
This often leads to the component function becoming asynchronous since some information needs to be fetched from remote API endpoints.

This pull requests contains some very minimal changes that allows async component functions to be registered instead of only normal ones by first awaiting the bodyComponent call before calling the page component. 